### PR TITLE
fix: 修复灰度设备下拉框显示异常

### DIFF
--- a/frontend/src/components/DeploymentForm.tsx
+++ b/frontend/src/components/DeploymentForm.tsx
@@ -184,7 +184,7 @@ const DeploymentForm: React.FC<DeploymentFormProps> = ({ onSuccess, onCancel }) 
             </option>
             {machines.map((machine) => (
               <option key={machine.id} value={machine.id}>
-                {machine.name} ({machine.ip})
+                {machine.name || machine.ip} {machine.name && `(${machine.ip})`}
               </option>
             ))}
           </select>


### PR DESCRIPTION
当机器名称为空时，下拉框直接显示IP地址，避免显示为空

Generated with [codeagent](https://github.com/qbox/codeagent)